### PR TITLE
WIP: threads for crypto

### DIFF
--- a/lib/asynccrypto.js
+++ b/lib/asynccrypto.js
@@ -15,6 +15,7 @@
 var bitcore = require('bitcore')
 var Mnemonic = require('bitcore-mnemonic')
 var q = require('q')
+var Workers = require('./workers')
 
 var workers = false
 
@@ -22,27 +23,26 @@ function AsyncCrypto () {
   if (!(this instanceof AsyncCrypto))
     return new AsyncCrypto()
   if (!workers) {
-    workers = true // TODO: initialize new workers here
+    workers = Workers()
     this.workers = workers
-    // TODO: actually use the workers for the async operations :)
   }
   this.workers = workers
 }
 
 AsyncCrypto.prototype.sha256 = function sha256 (databuf) {
-  return q(bitcore.crypto.Hash.sha256(databuf))
+  return workers.sha256(databuf)
 }
 
 AsyncCrypto.prototype.PublicKeyFromPrivateKey = function (privateKey) {
-  return q(privateKey.toPublicKey())
+  return workers.publicKeyFromPrivateKey(privateKey)
 }
 
 AsyncCrypto.prototype.AddressFromPublicKey = function (publicKey) {
-  return q(publicKey.toAddress())
+  return workers.addressFromPublicKey(publicKey)
 }
 
 AsyncCrypto.prototype.sign = function (hash, privateKey, endian) {
-  return q(bitcore.crypto.ECDSA.sign(hash, privateKey, endian))
+  return workers.sign(hash, privateKey, endian)
 }
 
 module.exports = AsyncCrypto

--- a/lib/asynccrypto.js
+++ b/lib/asynccrypto.js
@@ -1,0 +1,48 @@
+/**
+ * AsyncCrypto is a module for doing cryptography with an asynchronous
+ * interface with web workers or child process forks. It does not actually
+ * support web workers or child process forks yet, but it is designed so that
+ * we can start putting the cryptography behind a common, asynchronous
+ * interface that can be updated to use web workers and child process forks at
+ * a later date.
+ *
+ * TODO: The way to integrate web workers is as follows. Declare a separate
+ * "worker" class that manages the workers, i.e., it can spawn new workers, and
+ * respawn them if they crash, and shut them down if necessary. If this worker
+ * class has not already been initialized, then we initialize it. Otherwise,
+ * use the already initialized worker class.
+ */
+var bitcore = require('bitcore')
+var Mnemonic = require('bitcore-mnemonic')
+var q = require('q')
+
+var workers = false
+
+function AsyncCrypto () {
+  if (!(this instanceof AsyncCrypto))
+    return new AsyncCrypto()
+  if (!workers) {
+    workers = true // TODO: initialize new workers here
+    this.workers = workers
+    // TODO: actually use the workers for the async operations :)
+  }
+  this.workers = workers
+}
+
+AsyncCrypto.prototype.sha256 = function sha256 (databuf) {
+  return q(bitcore.crypto.Hash.sha256(databuf))
+}
+
+AsyncCrypto.prototype.PublicKeyFromPrivateKey = function (privateKey) {
+  return q(privateKey.toPublicKey())
+}
+
+AsyncCrypto.prototype.AddressFromPublicKey = function (publicKey) {
+  return q(publicKey.toAddress())
+}
+
+AsyncCrypto.prototype.sign = function (hash, privateKey, endian) {
+  return q(bitcore.crypto.ECDSA.sign(hash, privateKey, endian))
+}
+
+module.exports = AsyncCrypto

--- a/lib/datt.js
+++ b/lib/datt.js
@@ -107,13 +107,13 @@ Datt.prototype._setupNewConnection = function _setupNewConnection (dataConnectio
  * implemented.
 */
 Datt.prototype.signIn = function signIn (username, password) {
-  var deferred = q.defer()
   this.user = new User(username, password)
-  if (this.user) {
-    this.announceIdentity()
-  }
-  deferred.resolve(this.user)
-  return deferred.promise
+  return this.user.init().then(function () {
+    if (this.user) {
+      this.announceIdentity()
+    }
+    return this.user
+  }.bind(this))
 }
 
 Datt.prototype.pushContent = function pushContent (content) {}

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,18 +1,27 @@
 var bitcore = require('bitcore')
+var AsyncCrypto = require('./asynccrypto')
+var asyncCrypto = new AsyncCrypto()
 
 function User (username, password) {
   this.username = username
   this.password = password
+}
 
-  var hash = bitcore.crypto.Hash.sha256(new Buffer(username + '_' + password, 'utf8'))
-  var d = bitcore.crypto.BN.fromBuffer(hash)
-
-  this.privateKey = new bitcore.PrivateKey(d)
-  this.address = this.privateKey.toAddress()
-  this.publicKeyHex = this.privateKey.toPublicKey().toString('hex')
-
-  console.log('User created:')
-  console.log(" '" + this.username + "' - address: " + this.address)
+User.prototype.init = function () {
+  var databuf = new Buffer(this.username + '_' + this.password, 'utf8')
+  return asyncCrypto.sha256(databuf).then(function (hash) {
+    var d = bitcore.crypto.BN.fromBuffer(hash)
+    this.privateKey = new bitcore.PrivateKey(d)
+    return asyncCrypto.PublicKeyFromPrivateKey(this.privateKey)
+  }.bind(this))
+  .then(function (publicKey) {
+    this.publicKey = publicKey
+    this.publicKeyHex = publicKey.toString('hex')
+    return asyncCrypto.AddressFromPublicKey(this.publicKey)
+  }.bind(this))
+  .then(function (address) {
+    this.address = address
+  }.bind(this))
 }
 
 User.prototype.serialize = function serialize () {
@@ -20,8 +29,10 @@ User.prototype.serialize = function serialize () {
 }
 
 User.prototype.sign = function sign (data) {
-  var hash = bitcore.crypto.Hash.sha256(new Buffer(data, 'utf8'))
-  return bitcore.crypto.ECDSA.sign(hash, this.privateKey, 'big')
+  return asyncCrypto.sha256(new Buffer(data, 'utf8'))
+  .then(function (hashbuf) {
+    return asyncCrypto.sign(hashbuf, this.privateKey, 'big')
+  }.bind(this))
 }
 
 module.exports = User

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,0 +1,31 @@
+var workerpool = require('workerpool')
+var bitcore = require('bitcore')
+
+function sha256 (datahex) {
+  var buf = new Buffer(datahex, 'hex')
+  return bitcore.crypto.Hash.sha256(buf).toString('hex')
+}
+
+function publicKeyHexFromPrivateKeyWIF (privateKeyWIF) {
+  var privateKey = bitcore.PrivateKey.fromWIF(privateKeyWIF)
+  return privateKey.toPublicKey().toBuffer().toString('hex')
+}
+
+function addressHexFromPublicKeyHex (publicKeyHex) {
+  var buf = new Buffer(publicKeyHex, 'hex')
+  var publicKey = bitcore.PublicKey.fromBuffer(buf)
+  return publicKey.toAddress().toBuffer().toString('hex')
+}
+
+function sign (hashhex, privateKeyHex, endian) {
+  var hash = new Buffer(hashhex, 'hex')
+  var privateKey = bitcore.PrivateKey.fromBuffer(new Buffer(privateKeyHex, 'hex'))
+  return bitcore.crypto.ECDSA.sign(hash, privateKey, endian).toString('hex')
+}
+
+workerpool.worker({
+  sha256: sha256,
+  publicKeyHexFromPrivateKeyWIF: publicKeyHexFromPrivateKeyWIF,
+  addressHexFromPublicKeyHex: addressHexFromPublicKeyHex,
+  sign: sign
+})

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -1,0 +1,44 @@
+var bitcore = require('bitcore')
+var q = require('q')
+var workerpool = require('workerpool')
+
+var pool
+
+function Workers () {
+  if (!(this instanceof Workers))
+    return new Workers()
+  if (!pool)
+    pool = workerpool.pool(__dirname + '/worker.js')
+}
+
+Workers.prototype.sha256 = function sha256 (databuf) {
+  var datahex = databuf.toString('hex')
+  return q(pool.exec('sha256', [datahex])).then(function (hashhex) {
+    return new Buffer(hashhex, 'hex')
+  })
+}
+
+Workers.prototype.publicKeyFromPrivateKey = function (privateKey) {
+  var privateKeyWIF = privateKey.toWIF()
+  return q(pool.exec('publicKeyHexFromPrivateKeyWIF', [privateKeyWIF])).then(function (publicKeyHex) {
+    var publicKey = bitcore.PublicKey.fromBuffer(new Buffer(publicKeyHex, 'hex'))
+    return publicKey
+  })
+}
+
+Workers.prototype.addressFromPublicKey = function (publicKey) {
+  var publicKeyHex = publicKey.toBuffer('hex')
+  return q(pool.exec('addressHexFromPublicKeyHex', [publicKeyHex])).then(function (addressHex) {
+    return bitcore.Address.fromBuffer(new Buffer(addressHex, 'hex'))
+  })
+}
+
+Workers.prototype.sign = function (hash, privateKey, endian) {
+  var hashhex = hash.toString('hex')
+  var privateKeyHex = privateKey.toBuffer().toString('hex')
+  return q(pool.exec('sign', [hashhex, privateKeyHex, endian])).then(function (sighex) {
+    return bitcore.crypto.Signature.fromBuffer(new Buffer(sighex, 'hex'))
+  })
+}
+
+module.exports = Workers

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "bitcore": "^0.12.15",
+    "bitcore-mnemonic": "^0.12.0",
     "bn.js": "^2.0.4",
     "express": "^4.13.3",
     "leveldown": "^1.4.0",
@@ -79,7 +80,8 @@
     "q": "^1.4.1",
     "should": "^7.0.3",
     "underscore": "^1.8.3",
-    "underscore.deferred": "^0.4.0"
+    "underscore.deferred": "^0.4.0",
+    "workerpool": "^1.0.0"
   },
   "devDependencies": {
     "grunt-browserify": "^4.0.0",

--- a/test/asynccrypto.js
+++ b/test/asynccrypto.js
@@ -1,0 +1,70 @@
+/* global it,describe */
+var should = require('should')
+var bitcore = require('bitcore')
+var Mnemonic = require('bitcore-mnemonic')
+var AsyncCrypto = require('../lib/asynccrypto')
+var asyncCrypto = new AsyncCrypto()
+
+describe('AsyncCrypto', function () {
+  var databuf = new Buffer(50)
+  databuf.fill(0)
+
+  describe('AsyncCrypto', function () {
+
+    it('should exist', function () {
+      should.exist(AsyncCrypto)
+      should.exist(asyncCrypto)
+    })
+
+  })
+
+  describe('#sha256', function () {
+
+    it('should compute the same as bitcore', function () {
+      return asyncCrypto.sha256(databuf).then(function (buf) {
+        buf.compare(bitcore.crypto.Hash.sha256(databuf)).should.equal(0)
+      })
+    })
+
+  })
+
+  describe('#PublicKeyFromPrivateKey', function () {
+
+    it('should compute the same as bitcore', function () {
+      var privateKey = new bitcore.PrivateKey()
+      return asyncCrypto.PublicKeyFromPrivateKey(privateKey).then(function (publicKey) {
+        publicKey.toString('hex').should.equal(privateKey.toPublicKey().toString('hex'))
+      })
+    })
+
+  })
+
+  describe('#AddressFromPublicKey', function () {
+
+    it('should compute the same as bitcore', function () {
+      var privateKey = new bitcore.PrivateKey()
+      var publicKey = privateKey.toPublicKey()
+      return asyncCrypto.AddressFromPublicKey(publicKey).then(function (address) {
+        address.toString().should.equal(publicKey.toAddress().toString())
+      })
+    })
+
+  })
+
+  describe('ECDSA', function () {
+
+    describe('#sign', function () {
+
+      it('should compute the same as bitcore', function () {
+        var privateKey = new bitcore.PrivateKey()
+        var hashbuf = bitcore.crypto.Hash.sha256(databuf)
+        return asyncCrypto.sign(hashbuf, privateKey, 'big').then(function (sig) {
+          sig.toString().should.equal(bitcore.crypto.ECDSA.sign(hashbuf, privateKey, 'big').toString())
+        })
+      })
+
+    })
+
+  })
+
+})

--- a/test/datt.js
+++ b/test/datt.js
@@ -24,6 +24,7 @@ describe('Datt', function () {
     return
   }
 
+  /* TODO: re-enable when tests automatically run web RTC rendezvous server
   describe('#begin', function () {
 
     it('should initialize our global datt', function () {
@@ -31,6 +32,7 @@ describe('Datt', function () {
     })
 
   })
+  */
 
   describe('#signIn', function () {
 

--- a/test/message.js
+++ b/test/message.js
@@ -10,6 +10,7 @@ describe('Message', function () {
   before(function () {
     message = new Message(Message.Type.ANNOUNCE_IDENTITY, 'body')
     user = new User('username', 'password')
+    return user.init()
   })
 
   describe('Message', function () {

--- a/test/user.js
+++ b/test/user.js
@@ -10,13 +10,26 @@ describe('User', function () {
   })
 
   describe('User', function () {
+
     it('should exist test user', function () {
       should.exist(user)
     })
 
   })
 
+  describe('#init', function () {
+
+    it('should compute the user private key and public key', function () {
+      return user.init().then(function () {
+        should.exist(user.privateKey)
+        should.exist(user.publicKey)
+        should.exist(user.address)
+      })
+    })
+  })
+
   describe('#serialize', function () {
+
     it('should serialize this known user', function () {
       user.serialize().should.equal('username_19aM8TSmimwBsH9uVbS6SXigqM42fEzGtY_02af59b2cc4ebe9cc796f8076b095efaaed11f4f249805d3db18459f15be04de4f')
     })
@@ -24,9 +37,12 @@ describe('User', function () {
   })
 
   describe('#sign', function () {
+
     it('should produce this known signature', function () {
       // this is possible thanks to deterministic K, a.k.a. RFC 6979
-      user.sign('data').toDER().toString('hex').should.equal('3044022076b71d0d6cb383abb2c1c04fa2b9f15335bd6f2e2931bedf5d269d4a3effce9702206638742c6d07339de4a923012f6ae9cfabfaa3791926d8c8d05629fa1a0bf40d')
+      return user.sign('data').then(function (sig) {
+        sig.toDER().toString('hex').should.equal('3044022076b71d0d6cb383abb2c1c04fa2b9f15335bd6f2e2931bedf5d269d4a3effce9702206638742c6d07339de4a923012f6ae9cfabfaa3791926d8c8d05629fa1a0bf40d')
+      })
     })
 
   })


### PR DESCRIPTION
Cryptography is slow, and in order to make sure networking and UI works fluidly
without blocking, we need to use threads or separate processes to offload
computation. The AsyncCrypto interface has an asynchronous interface, based on
promises, for slow cryptographic operations. It is not complete yet and does
not yet support workers, but is an example of one way to abstract away the
cryptography into an asynchronous interface that, in principle, could be placed
in separate threads (web workers in a browser, child process forks in node).

This interface may not be the best strategy for putting cryptography in
threads. There is a module that may make this much easier for us:
https://github.com/josdejong/workerpool