### PR TITLE
Simplify AsyncCrypto interface

### DIFF
--- a/lib/asynccrypto.js
+++ b/lib/asynccrypto.js
@@ -5,14 +5,15 @@
  * isomorphic between node and a browser (i.e., it works in both).
  */
 var Workers = require('./workers')
-
 var workers = false
+var asyncCrypto
 
 function AsyncCrypto () {
   if (!(this instanceof AsyncCrypto)) {
     return new AsyncCrypto()
   }
   if (!workers) {
+    // cache global workers, so if you create
     workers = Workers()
     this.workers = workers
   }
@@ -33,6 +34,14 @@ AsyncCrypto.prototype.AddressFromPublicKey = function (publicKey) {
 
 AsyncCrypto.prototype.sign = function (hash, privateKey, endian) {
   return workers.sign(hash, privateKey, endian)
+}
+
+asyncCrypto = new AsyncCrypto()
+for (var method in AsyncCrypto.prototype) {
+  // This javascript wizardry makes it possible to use methods like
+  // AsyncCrypto.sha256 that will re-use the same global asyncCrypto object for
+  // convenience
+  AsyncCrypto[method] = AsyncCrypto.prototype[method].bind(asyncCrypto)
 }
 
 module.exports = AsyncCrypto

--- a/lib/asynccrypto.js
+++ b/lib/asynccrypto.js
@@ -8,32 +8,38 @@ var Workers = require('./workers')
 var workers = false
 var asyncCrypto
 
-function AsyncCrypto () {
+function AsyncCrypto (_workers) {
   if (!(this instanceof AsyncCrypto)) {
-    return new AsyncCrypto()
+    return new AsyncCrypto(_workers)
   }
-  if (!workers) {
-    // cache global workers, so if you create
-    workers = Workers()
+  if (!_workers) {
+    if (!workers) {
+      // Cache global workers, so if you create a new asyncCrypto instance it
+      // will use the global workers by default.
+      workers = Workers()
+    }
     this.workers = workers
+  } else {
+    // If you want to set your own workers, you can do so by specifying them in
+    // the constructor.
+    this.workers = _workers
   }
-  this.workers = workers
 }
 
 AsyncCrypto.prototype.sha256 = function sha256 (databuf) {
-  return workers.sha256(databuf)
+  return this.workers.sha256(databuf)
 }
 
 AsyncCrypto.prototype.PublicKeyFromPrivateKey = function (privateKey) {
-  return workers.publicKeyFromPrivateKey(privateKey)
+  return this.workers.publicKeyFromPrivateKey(privateKey)
 }
 
 AsyncCrypto.prototype.AddressFromPublicKey = function (publicKey) {
-  return workers.addressFromPublicKey(publicKey)
+  return this.workers.addressFromPublicKey(publicKey)
 }
 
 AsyncCrypto.prototype.sign = function (hash, privateKey, endian) {
-  return workers.sign(hash, privateKey, endian)
+  return this.workers.sign(hash, privateKey, endian)
 }
 
 asyncCrypto = new AsyncCrypto()

--- a/lib/asynccrypto.js
+++ b/lib/asynccrypto.js
@@ -30,11 +30,11 @@ AsyncCrypto.prototype.sha256 = function sha256 (databuf) {
   return this.workers.sha256(databuf)
 }
 
-AsyncCrypto.prototype.PublicKeyFromPrivateKey = function (privateKey) {
+AsyncCrypto.prototype.publicKeyFromPrivateKey = function (privateKey) {
   return this.workers.publicKeyFromPrivateKey(privateKey)
 }
 
-AsyncCrypto.prototype.AddressFromPublicKey = function (publicKey) {
+AsyncCrypto.prototype.addressFromPublicKey = function (publicKey) {
   return this.workers.addressFromPublicKey(publicKey)
 }
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -22,12 +22,12 @@ User.prototype.init = function () {
   this._readyPromise = AsyncCrypto.sha256(databuf).then((function (hash) {
     var d = bitcore.crypto.BN.fromBuffer(hash)
     this.privateKey = new bitcore.PrivateKey(d)
-    return AsyncCrypto.PublicKeyFromPrivateKey(this.privateKey)
+    return AsyncCrypto.publicKeyFromPrivateKey(this.privateKey)
   }).bind(this))
     .then((function (publicKey) {
       this.publicKey = publicKey
       this.publicKeyHex = publicKey.toString('hex')
-      return AsyncCrypto.AddressFromPublicKey(this.publicKey)
+      return AsyncCrypto.addressFromPublicKey(this.publicKey)
     }).bind(this))
     .then((function (address) {
       this.address = address

--- a/lib/user.js
+++ b/lib/user.js
@@ -3,7 +3,6 @@ var bitcore = require('bitcore')
 var util = require('./util')
 
 var AsyncCrypto = require('./asynccrypto')
-var asyncCrypto = new AsyncCrypto()
 
 var u = require('underscore')
 
@@ -20,15 +19,15 @@ User.prototype.init = function () {
   }
 
   var databuf = new Buffer(this.username + '_' + this.password, 'utf8')
-  this._readyPromise = asyncCrypto.sha256(databuf).then((function (hash) {
+  this._readyPromise = AsyncCrypto.sha256(databuf).then((function (hash) {
     var d = bitcore.crypto.BN.fromBuffer(hash)
     this.privateKey = new bitcore.PrivateKey(d)
-    return asyncCrypto.PublicKeyFromPrivateKey(this.privateKey)
+    return AsyncCrypto.PublicKeyFromPrivateKey(this.privateKey)
   }).bind(this))
     .then((function (publicKey) {
       this.publicKey = publicKey
       this.publicKeyHex = publicKey.toString('hex')
-      return asyncCrypto.AddressFromPublicKey(this.publicKey)
+      return AsyncCrypto.AddressFromPublicKey(this.publicKey)
     }).bind(this))
     .then((function (address) {
       this.address = address
@@ -62,9 +61,9 @@ User.prototype.serialize = function serialize () {
 }
 
 User.prototype.sign = function sign (data) {
-  return asyncCrypto.sha256(new Buffer(data, 'utf8'))
+  return AsyncCrypto.sha256(new Buffer(data, 'utf8'))
     .then((function (hashbuf) {
-      return asyncCrypto.sign(hashbuf, this.privateKey, 'big')
+      return AsyncCrypto.sign(hashbuf, this.privateKey, 'big')
     }).bind(this))
 }
 

--- a/test/asynccrypto.js
+++ b/test/asynccrypto.js
@@ -2,6 +2,7 @@
 var should = require('should')
 var bitcore = require('bitcore')
 var AsyncCrypto = require('../lib/asynccrypto')
+var Workers = require('../lib/workers')
 
 describe('AsyncCrypto', function () {
   var databuf = new Buffer(50)
@@ -20,6 +21,15 @@ describe('AsyncCrypto', function () {
       should.exist(asyncCrypto.PublicKeyFromPrivateKey)
       should.exist(asyncCrypto.AddressFromPublicKey)
       should.exist(asyncCrypto.sign)
+    })
+
+    it('should share the same default workers', function () {
+      var asyncCrypto = new AsyncCrypto()
+      var asyncCrypto2 = new AsyncCrypto()
+      asyncCrypto2.workers.should.equal(asyncCrypto.workers)
+      var workers = new Workers()
+      var asyncCrypto3 = new AsyncCrypto(workers)
+      asyncCrypto3.workers.should.not.equal(asyncCrypto.workers)
     })
 
   })

--- a/test/asynccrypto.js
+++ b/test/asynccrypto.js
@@ -12,14 +12,14 @@ describe('AsyncCrypto', function () {
     it('should exist', function () {
       should.exist(AsyncCrypto)
       should.exist(AsyncCrypto.sha256)
-      should.exist(AsyncCrypto.PublicKeyFromPrivateKey)
-      should.exist(AsyncCrypto.AddressFromPublicKey)
+      should.exist(AsyncCrypto.publicKeyFromPrivateKey)
+      should.exist(AsyncCrypto.addressFromPublicKey)
       should.exist(AsyncCrypto.sign)
       var asyncCrypto = new AsyncCrypto()
       should.exist(asyncCrypto)
       should.exist(asyncCrypto.sha256)
-      should.exist(asyncCrypto.PublicKeyFromPrivateKey)
-      should.exist(asyncCrypto.AddressFromPublicKey)
+      should.exist(asyncCrypto.publicKeyFromPrivateKey)
+      should.exist(asyncCrypto.addressFromPublicKey)
       should.exist(asyncCrypto.sign)
     })
 
@@ -43,21 +43,21 @@ describe('AsyncCrypto', function () {
 
   })
 
-  describe('@PublicKeyFromPrivateKey', function () {
+  describe('@publicKeyFromPrivateKey', function () {
     it('should compute the same as bitcore', function () {
       var privateKey = new bitcore.PrivateKey()
-      return AsyncCrypto.PublicKeyFromPrivateKey(privateKey).then(function (publicKey) {
+      return AsyncCrypto.publicKeyFromPrivateKey(privateKey).then(function (publicKey) {
         publicKey.toString('hex').should.equal(privateKey.toPublicKey().toString('hex'))
       })
     })
 
   })
 
-  describe('@AddressFromPublicKey', function () {
+  describe('@addressFromPublicKey', function () {
     it('should compute the same as bitcore', function () {
       var privateKey = new bitcore.PrivateKey()
       var publicKey = privateKey.toPublicKey()
-      return AsyncCrypto.AddressFromPublicKey(publicKey).then(function (address) {
+      return AsyncCrypto.addressFromPublicKey(publicKey).then(function (address) {
         address.toString().should.equal(publicKey.toAddress().toString())
       })
     })

--- a/test/asynccrypto.js
+++ b/test/asynccrypto.js
@@ -2,7 +2,6 @@
 var should = require('should')
 var bitcore = require('bitcore')
 var AsyncCrypto = require('../lib/asynccrypto')
-var asyncCrypto = new AsyncCrypto()
 
 describe('AsyncCrypto', function () {
   var databuf = new Buffer(50)
@@ -11,35 +10,44 @@ describe('AsyncCrypto', function () {
   describe('AsyncCrypto', function () {
     it('should exist', function () {
       should.exist(AsyncCrypto)
+      should.exist(AsyncCrypto.sha256)
+      should.exist(AsyncCrypto.PublicKeyFromPrivateKey)
+      should.exist(AsyncCrypto.AddressFromPublicKey)
+      should.exist(AsyncCrypto.sign)
+      var asyncCrypto = new AsyncCrypto()
       should.exist(asyncCrypto)
+      should.exist(asyncCrypto.sha256)
+      should.exist(asyncCrypto.PublicKeyFromPrivateKey)
+      should.exist(asyncCrypto.AddressFromPublicKey)
+      should.exist(asyncCrypto.sign)
     })
 
   })
 
-  describe('#sha256', function () {
+  describe('@sha256', function () {
     it('should compute the same as bitcore', function () {
-      return asyncCrypto.sha256(databuf).then(function (buf) {
+      return AsyncCrypto.sha256(databuf).then(function (buf) {
         buf.compare(bitcore.crypto.Hash.sha256(databuf)).should.equal(0)
       })
     })
 
   })
 
-  describe('#PublicKeyFromPrivateKey', function () {
+  describe('@PublicKeyFromPrivateKey', function () {
     it('should compute the same as bitcore', function () {
       var privateKey = new bitcore.PrivateKey()
-      return asyncCrypto.PublicKeyFromPrivateKey(privateKey).then(function (publicKey) {
+      return AsyncCrypto.PublicKeyFromPrivateKey(privateKey).then(function (publicKey) {
         publicKey.toString('hex').should.equal(privateKey.toPublicKey().toString('hex'))
       })
     })
 
   })
 
-  describe('#AddressFromPublicKey', function () {
+  describe('@AddressFromPublicKey', function () {
     it('should compute the same as bitcore', function () {
       var privateKey = new bitcore.PrivateKey()
       var publicKey = privateKey.toPublicKey()
-      return asyncCrypto.AddressFromPublicKey(publicKey).then(function (address) {
+      return AsyncCrypto.AddressFromPublicKey(publicKey).then(function (address) {
         address.toString().should.equal(publicKey.toAddress().toString())
       })
     })
@@ -47,11 +55,11 @@ describe('AsyncCrypto', function () {
   })
 
   describe('ECDSA', function () {
-    describe('#sign', function () {
+    describe('@sign', function () {
       it('should compute the same as bitcore', function () {
         var privateKey = new bitcore.PrivateKey()
         var hashbuf = bitcore.crypto.Hash.sha256(databuf)
-        return asyncCrypto.sign(hashbuf, privateKey, 'big').then(function (sig) {
+        return AsyncCrypto.sign(hashbuf, privateKey, 'big').then(function (sig) {
           sig.toString().should.equal(bitcore.crypto.ECDSA.sign(hashbuf, privateKey, 'big').toString())
         })
       })


### PR DESCRIPTION
You used to have to create a new AsyncCrypto instance in order to use it, because it kept track of its own workers. You can now use static methods, and it will automatically create a new AsyncCrypto for global use if you do so. For instance, you can just call AsyncCrypto.sha256(data) to get back a promise to a hash, which will be computed in the default global workers. If for some reason you want to override the default workers, you can now do so as well, by calling, say, <code>var asyncCrypto = new AsyncCrypto(workers)</code> and then <code>asyncCrypto.sha256(data)</code> which will hash the data using your custom workers. This might be useful for testing or for some special computation that shouldn't run in the default global worker pool.