### PR TITLE
Use AsyncCrypto.sha256 in Content (WIP #19)

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -2,6 +2,9 @@ var bitcore = require('bitcore')
 var q = require('q')
 var u = require('underscore')
 
+var AsyncCrypto = require('./asynccrypto')
+var asyncCrypto = new AsyncCrypto()
+
 function Content (data, owner_username, owner_address, post_time, post_height, owner_pubkey, signature) {
   this.data = data
   this._owner_username = q(owner_username)
@@ -24,21 +27,35 @@ Content.prototype.init = function () {
     return (this.owner_username = username)
   }).bind(this))
 
-  var pOwnerAddress = this.setOwnerAddress(this._owner_address)
-  var pPubKey = this.setOwnerPubKey(this._owner_pubkey)
+  var pOwnerAddress = (this._owner_address? this.setOwnerAddress(this._owner_address) : q.resolve(null))
+  var pPubKey = (this._owner_pubkey? this.setOwnerPubKey(this._owner_pubkey) : q.resolve(null))
 
   // set signature (if provided) and verify consistency with above
 
-  this._readyPromise = q.when(pUsername, pPubKey, pOwnerAddress).then((function () {
-    delete this._owner_username
-    delete this._owner_pubkey
-    delete this._owner_address
-    var pSig = this.setSignature(this._signature)
-    return pSig.then((function () {
-      delete this._signature
-      return this
-    }).bind(this))
-  }).bind(this))
+  this._readyPromise = q.when(pUsername, pPubKey, pOwnerAddress).then(
+      (function () {
+        delete this._owner_username
+        delete this._owner_pubkey
+        delete this._owner_address
+        return this.setSignature(this._signature)
+      }).bind(this)
+  ).then(
+      (function () {
+        delete this._signature
+        if (this.getBufferToHash()) {
+          return asyncCrypto.sha256(this.getBufferToHash())
+        } else {
+          return null
+        }
+      }).bind(this)
+  ).then(
+      (function (hashbuf) {
+        if (hashbuf) {
+          this._hashbuf = hashbuf
+        }
+        return this
+      }).bind(this)
+  )
 
   return this._readyPromise
 
@@ -56,12 +73,11 @@ Content.fromDataAndUser = function fromDataAndUser (data, user, post_time, post_
   })
 }
 
-Content.prototype.setOwnerPubKey = function setOwnerPubKey (pubkey) {
-  return q(pubkey).then((function (pubkey) {
+Content.prototype.setOwnerPubKey = q.promised(function setOwnerPubKey (pubkey) {
     console.log('Content#setOwnerPubKey: ' + pubkey)
+    console.log(this instanceof Content)
     if (!pubkey) {
-      return q.resolve(null)
-    // throw new Error("Content#setOwnerPubKey requires non-null, defined argument containing public key of owner")
+      return null
     }
 
     if (typeof (pubkey) !== 'string') {
@@ -77,24 +93,25 @@ Content.prototype.setOwnerPubKey = function setOwnerPubKey (pubkey) {
     this.owner_pubkey = pubkey
 
     if (!this.owner_address) {
-      this.setOwnerAddress(expected_address)
+      return this.setOwnerAddress(expected_address).then(function() {
+	  return this.owner_pubkey
+      }.bind(this))
     }
 
     console.log("Content#setOwnerPubKey: set owner pub key = '" + pubkey + "'")
-    return q(this.owner_pubkey)
-  }).bind(this))
-}
+
+    return this.owner_pubkey
+})
 
 Content.prototype.getOwnerPubKey = function getOwnerPubKey () {
   return this.owner_pubkey
 }
 
-Content.prototype.setOwnerAddress = function setOwnerAddress (address) {
-  return q(address).then((function (address) {
+Content.prototype.setOwnerAddress = q.promised(function setOwnerAddress (address) {
     console.log('Content#setOwnerAddress: ' + address)
+
     if (!address) {
-      return q.resolve(null)
-    // throw new Error("Content#setOwnerAddress requires non-null, defined argument containing address of owner")
+      return null
     }
 
     // Need to do this, even if already string, just for validation
@@ -108,9 +125,8 @@ Content.prototype.setOwnerAddress = function setOwnerAddress (address) {
     }
     this.owner_address = address
 
-    return q(this.owner_address)
-  }).bind(this))
-}
+    return this.owner_address
+})
 
 Content.prototype.serialize = function serialize () {
   return Content.serialize(this)
@@ -182,11 +198,20 @@ Content.prototype.getSignature = function getSignature () {
 }
 
 Content.prototype._getSignatureObject = function _getSignatureObject () {
-  return bitcore.crypto.Signature.fromString(this.getSignature())
+  if(this.getSignature()) {
+      return bitcore.crypto.Signature.fromString(this.getSignature())
+  } else {
+      return null
+  }
 }
 
 Content.prototype.getSignatureBuffer = function getSignatureBuffer () {
-  return this._getSignatureObject().toBuffer()
+  var obj = this._getSignatureObject()
+  if(obj) {
+      return obj.toBuffer()
+  } else {
+      return null
+  }
 }
 
 Content.prototype.getSignatureHex = function getSignatureHex () {
@@ -215,11 +240,16 @@ Content.prototype.getPostTime = function getPostTime () {
 
 Content.prototype.getOwnerBuffer = function getOwnerBuffer () {
   // return new Buffer(this.getOwnerAddress(), 'utf8')
-  return new Buffer(this.getOwnerPubKey(), 'utf8')
+  
+  return (this.getOwnerPubKey()? new Buffer(this.getOwnerPubKey(), 'utf8') : null)
 }
 
 Content.prototype.getBufferToHash = function getBufferToHash () {
   // var buffer = this.getDataBuffer()
+  if(!this.getDataBuffer() || !this.getOwnerBuffer() || !this.getSignatureBuffer()) {
+      return null
+  } 
+
   var buffer = Buffer.concat([this.getDataBuffer(), this.getOwnerBuffer(), this.getSignatureBuffer()])
   return buffer
 }

--- a/test/content.js
+++ b/test/content.js
@@ -203,11 +203,10 @@ describe('Content', function () {
 
         return newContent.setOwnerPubKey(testuser.getPubKey())
       }).then(function () {
-        newContent.getOwnerPubKey().should.eql(testuser.getPubKey())
-        newContent.getOwnerAddress().should.eql(testuser.getAddress())
+        testuser.getPubKey().should.eql(newContent.getOwnerPubKey())
+        testuser.getAddress().should.eql(newContent.getOwnerAddress())
       }).catch(function (err) {
-        should.not.exist(err)
-        should.fail('Should not throw this error: ' + err)
+        should.fail('Should not throw this error: ' + err + "\n\n " + err.stack )
       })
     })
 
@@ -325,10 +324,11 @@ describe('Content', function () {
 
         return newContent.setSignature(signatureStr)
       }).then(function () {
+	should.ok(newContent.getSignature())
         newContent.getSignature().should.eql(signatureStr)
       })
       .catch(function (err) {
-        should.fail(err)
+        should.fail(err + "\n\n" + err.stack)
       })
     })
 


### PR DESCRIPTION
- Now using AsyncCrypto.sha256 in Content rather than bitcore.crypto.Hash.sha256.
- Content#setOwnerAddress / Content#setOwnerPubKey don't handle promise inputs or wrap outputs, use q.promisify instead (cleaner)
- improved error handling in getHashBuffer / getOwnerBuffer
- For removing rest of bitcore calls, depends on #24, which adds (a) Signature verification, (b) Signature constructors, and (c) PubKey and Address validation to AsyncCrypto