### PR TITLE
AsyncCrypto: Add "verifySignature" method (#24)

### DIFF
--- a/lib/asynccrypto.js
+++ b/lib/asynccrypto.js
@@ -42,6 +42,10 @@ AsyncCrypto.prototype.sign = function (hash, privateKey, endian) {
   return this.workers.sign(hash, privateKey, endian)
 }
 
+AsyncCrypto.prototype.verifySignature = function verifySignature (hash, signature, publicKey) {
+  return this.workers.verifySignature(hash, signature, publicKey)
+}
+
 asyncCrypto = new AsyncCrypto()
 for (var method in AsyncCrypto.prototype) {
   // This javascript wizardry makes it possible to use methods like

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -30,11 +30,25 @@ function sign (hashhex, privateKeyHex, endian) {
   return bitcore.crypto.ECDSA.sign(hash, privateKey, endian).toString('hex')
 }
 
+function verifySignature (hashhex, signatureHex, publicKeyHex) {
+  var hash = new Buffer(hashhex, 'hex')
+  try {
+    var publicKey = bitcore.PublicKey.fromBuffer(new Buffer(publicKeyHex, 'hex'))
+    var signature = bitcore.crypto.Signature.fromBuffer(new Buffer(signatureHex, 'hex'))
+    return bitcore.crypto.ECDSA.verify(hash, signature, publicKey)
+  } catch (exc) {
+    console.error(exc)
+    console.error(exc.stack)
+    throw exc
+  }
+}
+
 var f = {
   sha256: sha256,
   publicKeyHexFromPrivateKeyObject: publicKeyHexFromPrivateKeyObject,
   addressHexFromPublicKeyHex: addressHexFromPublicKeyHex,
-  sign: sign
+  sign: sign,
+  verifySignature: verifySignature
 }
 
 if (workerpool) {

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -50,4 +50,21 @@ Workers.prototype.sign = function (hash, privateKey, endian) {
   })
 }
 
+Workers.prototype.verifySignature = function (hash, signature, publicKey) {
+  if (!hash || !signature || !publicKey) {
+    return q.reject(new Error('Workers#verifySignature needs 3 non-null, defined arguments: hash, signature, and publicKey'))
+  }
+  try {
+    var hashhex = hash.toString('hex')
+    var publicKeyHex = publicKey.toBuffer().toString('hex')
+    var signatureHex = signature.toBuffer().toString('hex')
+
+    return q(pool.exec('verifySignature', [hashhex, signatureHex, publicKeyHex]))
+  } catch (exc) {
+    console.error(exc)
+    console.error(exc.stack)
+    return q.reject(exc)
+  }
+}
+
 module.exports = Workers


### PR DESCRIPTION
- Added verifySignature(hash, signature, publicKey)
- calls bitcore.crypto.ECDSA.verify
- tests for valid signature, invalid signature, and missing arguments
- resolves #24 