### PR TITLE
Replace last of Content's ECDSA.verify / sha256 with AsyncCrypto (resolve #19)

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -254,8 +254,7 @@ Content.prototype.getBufferToHash = function getBufferToHash () {
 }
 
 Content.prototype.getHashBuffer = function getHash () {
-  var hashbuf = this._hashBuf || bitcore.crypto.Hash.sha256(this.getBufferToHash())
-  this._hashbuf = hashbuf
+  var hashbuf = this._hashbuf
 
   return hashbuf
 }
@@ -297,9 +296,9 @@ Content.verifySignature = q.promised(function verifySignature (data, signature, 
     signature = bitcore.crypto.Signature.fromBuffer(signature)
   }
 
-  var hash = bitcore.crypto.Hash.sha256(data)
-
-  return bitcore.crypto.ECDSA.verify(hash, signature, publicKey)
+  return AsyncCrypto.sha256(data).then(function(hash) {
+      return AsyncCrypto.verifySignature(hash, signature, publicKey)
+  })
 })
 
 Content.serialize = function serialize (content) {


### PR DESCRIPTION
- Use new AsyncCrypto.verifySignature (#24 added)
- Removes last expensive main-thread crypto from Content and closes #19 